### PR TITLE
Python version requirements in contributing.rst

### DIFF
--- a/doc/user/contributing.rst
+++ b/doc/user/contributing.rst
@@ -126,7 +126,6 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the merge request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 3.6, 3.7, 3.8 and 3.9. Check
+3. The pull request should work for Python >=3.10. Check
    https://github.com/simonbesnard1/gedidb/pulls
    and make sure that the tests pass for all supported Python versions.
-


### PR DESCRIPTION
This updates the Python version requirement in `contributing.rst` to match what is specified in the `pyroject.toml`. 

--- 

This PR is part of https://github.com/openjournals/joss-reviews/issues/8593; see the meta-tracking issue here: #39 