### PR TITLE
Switch GitLab to GitHub everywhere

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -187,7 +187,7 @@ html_theme_options = {
         "image_light": "_static/logos/gediDB_logo.svg",
         "image_dark": "_static/logos/gediDB_logo.svg",
     },
-    "gitlab_url": "https://github.com/simonbesnard1/gedidb",
+    "github_url": "https://github.com/simonbesnard1/gedidb",
     "collapse_navigation": True,
     "header_links_before_dropdown": 6,
     "navbar_end": ["search-button", "theme-switcher", "navbar-icon-links"],

--- a/doc/user/contributing.rst
+++ b/doc/user/contributing.rst
@@ -36,13 +36,13 @@ If you are reporting a bug, please include:
 Fix Bugs
 ~~~~~~~~
 
-Look through the GitLab issues for bugs. Anything tagged with "bug" and "help
+Look through the GitHub issues for bugs. Anything tagged with "bug" and "help
 wanted" is open to whoever wants to implement it.
 
 Implement Features
 ~~~~~~~~~~~~~~~~~~
 
-Look through the GitLab issues for features. Anything tagged with "enhancement"
+Look through the GitHub issues for features. Anything tagged with "enhancement"
 and "help wanted" is open to whoever wants to implement it.
 
 Write Documentation
@@ -72,7 +72,7 @@ Commit Changes
 How to
 ~~~~~~
 
-1. Fork the `gedidb` repo on GitLab.
+1. Fork the `gedidb` repo on GitHub.
 2. Clone your fork locally::
 
     $ git clone git@github.com:simonbesnard1/gedidb.git
@@ -99,13 +99,13 @@ How to
 
    To get flake8 and tox, just pip install them into your virtualenv.
 
-6. Commit your changes and push your branch to GitLab::
+6. Commit your changes and push your branch to GitHub::
 
     $ git add .
     $ git commit -m "Your detailed description of your changes."
     $ git push origin name-of-your-bugfix-or-feature
 
-7. Submit a merge request through the GitLab website.
+7. Submit a merge request through the GitHub website.
 
 Sign your commits
 ~~~~~~~~~~~~~~~~~

--- a/doc/user/installing.rst
+++ b/doc/user/installing.rst
@@ -84,7 +84,7 @@ To include optional dependencies:
 Development Versions
 --------------------
 
-To install the latest development version from GitLab:
+To install the latest development version from GitHub:
 
 .. code-block:: bash
 

--- a/doc/user/tiledb_database.rst
+++ b/doc/user/tiledb_database.rst
@@ -253,7 +253,7 @@ Here are some example use cases:
 Resources
 ---------
 - `TileDB Documentation <https://tiledb.com/docs>`_
-- `gediDB GitLab Repository <https://github.com/simonbesnard1/gedidb>`_
+- `gediDB GitHub Repository <https://github.com/simonbesnard1/gedidb>`_
 - `GEDI Data Products Overview <https://gedi.umd.edu>`_
 
    


### PR DESCRIPTION
gedidb is hosted here on GitHub, and all the docs links to version control point to this GitHub repository, but it's often referenced as GitLab instead of GitHub (migrated?). 

I've changed every GitLab I found to GitHub, as well as changing the Pydata Sphinx theme to use a GitHub icon instead of a GitLab one (please confirm this works correctly!)

--- 

This PR is part of https://github.com/openjournals/joss-reviews/issues/8593; see the meta-tracking issue here: #39 