### PR TITLE
Use `data_config.yml` everwhere

### DIFF
--- a/doc/user/fundamentals.processor.rst
+++ b/doc/user/fundamentals.processor.rst
@@ -25,7 +25,7 @@ Below is a quick example of using the :py:class:`gedidb.GEDIProcessor` in a work
 
    import gedidb as gdb
 
-   config_file = 'path/to/config_file.yml'
+   config_file = 'path/to/data_config.yml'
    geometry = 'path/to/test.geojson'
    
    # Initialize the GEDIProcessor and compute

--- a/doc/user/quick-overview.rst
+++ b/doc/user/quick-overview.rst
@@ -23,7 +23,7 @@ This setup initiates the download, processing, and storage of GEDI data in your 
 .. code-block:: python
 
     # Paths to configuration files
-    config_file = 'path/to/config_file.yml'
+    config_file = 'path/to/data_config.yml'
     geometry = 'path/to/test.geojson'
 
     # Initialize a parallel engine


### PR DESCRIPTION
The quick start guide and the data processing fundamentals are the only places the example file name for `config_file` is `config_file.yml`. Everywhere else, including the specific configuration files docs page, uses `data_config.yml` (~80 locations).

This PR changes the two `config_file.yml`s to `data_config.yml` for consistency. 

--- 

This PR is part of https://github.com/openjournals/joss-reviews/issues/8593; see the meta-tracking issue here: #39 